### PR TITLE
Update iterator usage on shapely MultiPolygon

### DIFF
--- a/spated/h3_utils.py
+++ b/spated/h3_utils.py
@@ -56,7 +56,7 @@ def generate_H3_discretization(gdf: GeoDataFrame, resolution: int = 7):
     hex_indexes = set()
     for observation in h3_gdf.geometry:
         if observation.geom_type == "MultiPolygon":
-            for polygon in observation:
+            for polygon in observation.geoms:
                 geoJson = polygon_to_geojson(polygon)
                 # h3.polyfill is the important method in the H3 library
                 # that does the heavy work of finding a good hex-cover


### PR DESCRIPTION
Shapely multipolygons are no longer iterable as of version 2.0 (see "Multi-part geometries will no longer be sequences” on https://shapely.readthedocs.io/en/stable/migration.html . Thus it is now needed to access the .geoms attribute for the same functionality.   